### PR TITLE
fix typo in externs

### DIFF
--- a/resources/externs/processing.js
+++ b/resources/externs/processing.js
@@ -97,7 +97,7 @@ PImage.prototype.mask = function(mask){};
 Processing.prototype.createImage = function(w, h, mode){};
 
 var pixels = {};
-pixels.prototype.getLenght = function(){};
+pixels.prototype.getLength = function(){};
 pixels.prototype.getPixel = function(i){};
 pixels.prototype.setPixel = function(i, c){};
 pixels.prototype.toArray = function(){};


### PR DESCRIPTION
fixes typo declaring pixels.prototype.getLength() method
